### PR TITLE
feat: added error treatment for unexpected cases

### DIFF
--- a/src/cep/mod.rs
+++ b/src/cep/mod.rs
@@ -41,6 +41,19 @@ pub struct CepServiceError {
     pub service: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Errored {
+    NotFound(CepError),
+    Unexpected,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnexpectedError {
+    pub code: u16,
+    pub message: String,
+    pub error: Errored,
+}
+
 /// Faz um GET Request para a API de CEP do Brasil API e retorna o CEP mais detalhado possível.
 ///
 /// Argumentos:
@@ -50,21 +63,32 @@ pub struct CepServiceError {
 /// Retorna:
 ///
 /// Result<Cep, CepError>
-pub async fn get_cep(cep_code: &str) -> Result<Cep, CepError> {
+pub async fn get_cep(cep_code: &str) -> Result<Cep, UnexpectedError> {
     let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
-
     let response = reqwest::get(&url).await.unwrap();
 
-    if response.status().as_u16() == 404 {
-        let body = response.text().await.unwrap();
-        let cep: CepError = serde_json::from_str(&body).unwrap();
+    match response.status().as_u16() {
+        200 => {
+            let body = response.text().await.unwrap();
+            let cep: Cep = serde_json::from_str(&body).unwrap();
 
-        Err(cep)
-    } else {
-        let body = response.text().await.unwrap();
-        let cep: Cep = serde_json::from_str(&body).unwrap();
+            Ok(cep)
+        },
+        404 => {
+            let body = response.text().await.unwrap();
+            let cep_err: CepError = serde_json::from_str(&body).unwrap();
 
-        Ok(cep)
+            Err(UnexpectedError {
+                code: 404,
+                message: format!("Not founded cep: {}", cep_code),
+                error: Errored::NotFound(cep_err),
+            })
+        },
+        code => Err(UnexpectedError {
+            code,
+            message: format!("Unexpected error with code: {}", code),
+            error: Errored::Unexpected,
+        }),
     }
 }
 
@@ -77,10 +101,19 @@ pub async fn get_cep(cep_code: &str) -> Result<Cep, CepError> {
 /// Retorna:
 ///
 /// Um valor booleano indicando se o CEP é válido ou não.
-pub async fn validate(cep_code: &str) -> bool {
+pub async fn validate(cep_code: &str) -> Result<bool, UnexpectedError> {
     let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
 
     let response = reqwest::get(&url).await.unwrap();
 
-    response.status().as_u16() == 200
+    match response.status().as_u16() {
+        200 => {
+            Ok(true)
+        },
+        code => Err(UnexpectedError {
+            code,
+            message: format!("Unexpected error with code: {}", code),
+            error: Errored::Unexpected,
+        }),
+    }
 }

--- a/src/cep/mod.rs
+++ b/src/cep/mod.rs
@@ -54,6 +54,20 @@ pub struct UnexpectedError {
     pub error: Errored,
 }
 
+pub struct CepService;
+
+impl CepService {
+    async fn get_cep(cep_code: &str) -> Result<reqwest::Response, reqwest::Error> {
+        let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
+        reqwest::get(&url).await
+    }
+
+    async fn get_cep_validation(cep_code: &str) -> Result<reqwest::Response, reqwest::Error> {
+        let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
+        reqwest::get(&url).await
+    }
+}
+
 /// Faz um GET Request para a API de CEP do Brasil API e retorna o CEP mais detalhado possível.
 ///
 /// Argumentos:
@@ -62,10 +76,9 @@ pub struct UnexpectedError {
 ///
 /// Retorna:
 ///
-/// Result<Cep, CepError>
+/// Result<Cep, UnexpectedError>
 pub async fn get_cep(cep_code: &str) -> Result<Cep, UnexpectedError> {
-    let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
-    let response = reqwest::get(&url).await.unwrap();
+    let response = CepService::get_cep(cep_code).await.unwrap();
 
     match response.status().as_u16() {
         200 => {
@@ -100,11 +113,9 @@ pub async fn get_cep(cep_code: &str) -> Result<Cep, UnexpectedError> {
 ///
 /// Retorna:
 ///
-/// Um valor booleano indicando se o CEP é válido ou não.
+/// Um resultado com valor booleano indicando se o CEP é válido ou não ou o mapeamento do erro.
 pub async fn validate(cep_code: &str) -> Result<bool, UnexpectedError> {
-    let url = format!("{}/api/cep/v2/{}", BRASIL_API_URL, cep_code);
-
-    let response = reqwest::get(&url).await.unwrap();
+    let response = CepService::get_cep_validation(cep_code).await.unwrap();
 
     match response.status().as_u16() {
         200 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,6 @@ mod tests {
     async fn validate() {
         let cep = cep::validate("01001000").await;
 
-        assert!(cep);
+        assert!(cep.unwrap());
     }
 }


### PR DESCRIPTION
When we deal with an external api is good to cover cases of error when some changes occur without our control, this experience come from an module I have created and the API just disappear from public. Just an improvement for error on this case.