### PR TITLE
feat: holidays

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Error {
+    pub message: String,
+    pub name: String,
+
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Errored {
+    NotFound(Error),
+    Unexpected,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnexpectedError {
+    pub code: u16,
+    pub message: String,
+    pub error: Errored,
+}

--- a/src/holidays/mod.rs
+++ b/src/holidays/mod.rs
@@ -1,0 +1,60 @@
+use crate::{
+    error::{Error, Errored, UnexpectedError},
+    spec::BRASIL_API_URL,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Holiday {
+    date: String,
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+    full_name: Option<String>,
+}
+
+pub struct HolidayService;
+
+impl HolidayService {
+    async fn get_holiday_request(year: &str) -> Result<reqwest::Response, reqwest::Error> {
+        let url = format!("{}/api/feriados/v1/{}", BRASIL_API_URL, year);
+
+        reqwest::get(&url).await
+    }
+}
+
+/// ## `get_holidays(year: &str)`
+/// Lista os feriados nacionais de determinado ano.
+///
+/// ### Argumento
+/// * `year:&str` => Ano para calcular os feriados.
+///
+/// ### Retorno
+/// * `Result<Vec<Holiday>, UnexpectedError>`
+///
+/// # Example
+///  ```
+/// use brasilapi::holidays;
+/// use brasilapi::holidays::Holiday;
+///
+/// let holidays:Vec<Holiday> = holidays::get_holidays("2022").await.unwrap();
+/// ```
+pub async fn get_holidays(year: &str) -> Result<Vec<Holiday>, UnexpectedError> {
+    let response = HolidayService::get_holiday_request(year).await.unwrap();
+
+    let status = response.status().as_u16();
+
+    if status != 200 {
+        let error: Error = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+
+        return Err(UnexpectedError {
+            code: status,
+            message: error.clone().message,
+            error: Errored::NotFound(error),
+        });
+    }
+
+    let holidays: Vec<Holiday> = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+
+    Ok(holidays)
+}

--- a/src/holidays/mod.rs
+++ b/src/holidays/mod.rs
@@ -31,9 +31,8 @@ impl HolidayService {
 ///
 /// ### Retorno
 /// * `Result<Vec<Holiday>, UnexpectedError>`
-///
 /// # Example
-///  ```
+///  ```ignore
 /// use brasilapi::holidays;
 /// use brasilapi::holidays::Holiday;
 ///
@@ -71,7 +70,7 @@ pub async fn get_holidays(year: &str) -> Result<Vec<Holiday>, UnexpectedError> {
 /// * `Result<Holiday, UnexpectedError>`
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// use brasilapi::holidays;
 /// use brasilapi::holidays::Holiday;
 ///

--- a/src/holidays/mod.rs
+++ b/src/holidays/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Holiday {
     date: String,
     #[serde(rename = "type")]
@@ -102,5 +102,41 @@ pub async fn get_holiday(year: &str, month: &str, day: &str) -> Result<Holiday, 
         Err(error) => {
             return Err(error);
         }
+    }
+}
+
+#[cfg(test)]
+
+mod holidays_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn get_holidays_test() {
+        let holidays = get_holidays("2022").await.unwrap();
+
+        let holyday = get_holiday("2022", "01", "01").await.unwrap();
+
+        assert!(holidays.contains(&holyday));
+    }
+
+    #[tokio::test]
+    async fn get_holidays_error_test() {
+        let holidays = get_holidays("2").await;
+
+        assert!(holidays.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_holiday_test() {
+        let holiday = get_holiday("2022", "09", "07").await.unwrap();
+
+        assert_eq!(holiday.name, "Independência do Brasil");
+    }
+
+    #[tokio::test]
+    async fn get_holiday_error_test() {
+        let holiday = get_holiday("2022", "10", "02").await;
+
+        assert!(holiday.is_err());
     }
 }

--- a/src/holidays/mod.rs
+++ b/src/holidays/mod.rs
@@ -58,3 +58,49 @@ pub async fn get_holidays(year: &str) -> Result<Vec<Holiday>, UnexpectedError> {
 
     Ok(holidays)
 }
+
+/// ## `get_holiday(year: &str, month: &str, day: &str)`
+/// Retorna um feriado a partir de uma data.
+///
+/// ### Argumento
+/// * `year:&str`   => Ano do feriado.
+/// * `month:&str`  => Mês do feriado.
+/// * `day:&str`    => Dia do feriado.
+///
+/// ### Retorno
+/// * `Result<Holiday, UnexpectedError>`
+///
+/// # Example
+/// ```
+/// use brasilapi::holidays;
+/// use brasilapi::holidays::Holiday;
+///
+/// let holiday:Holiday = holidays::get_holiday("2022", "09", "07").await.unwrap();
+/// ```
+pub async fn get_holiday(year: &str, month: &str, day: &str) -> Result<Holiday, UnexpectedError> {
+    let response = get_holidays(year).await;
+
+    match response {
+        Ok(holidays) => {
+            let holiday_position = holidays
+                .iter()
+                .position(|holiday| holiday.date == format!("{year}-{month}-{day}"));
+
+            match holiday_position {
+                Some(position) => {
+                    return Ok(holidays.get(position).unwrap().clone());
+                }
+                None => {
+                    return Err(UnexpectedError {
+                        code: 404,
+                        message: String::from("holiday not found"),
+                        error: Errored::Unexpected,
+                    });
+                }
+            }
+        }
+        Err(error) => {
+            return Err(error);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,6 @@ pub mod bank;
 pub mod cep;
 pub mod cnpj;
 pub mod ddd;
+pub mod error;
+pub mod holidays;
 pub mod spec;


### PR DESCRIPTION
Estou adicionando minha primeira contribuição ao projeto BrasilAPI em Rust com a adição duas funções de consulta às informações dos feriados:

- **get_holidays**: Lista os feriados nacionais de determinado ano.
- **get_holiday**: Retorna um feriado a partir de uma data.